### PR TITLE
Promisify and add timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,35 @@ creature.on('ready', function () {
 });
 ```
 
+It is possible to define a `timeout` either globally or local to each callback, together with a corresponding `timeoutVal` value. The callback is then invoked with the local value or if not set the global value (default: no callback invoked on timeout):
+
+```javascript
+var primus = Primus.connect('ws://localhost:8080');
+
+// connect to resource
+var creature = primus.resource('creature');
+creature.timeout = 5000;  // global default timeout, associated value is the undefined value
+
+// wait until resource is ready
+creature.on('ready', function () {
+  
+  // start calling remote events
+  creature.command('sleep', function (res) {
+    console.log(res);
+  });
+
+  // call the server remote walk event
+  var cbWalk = function (res) {
+    console.log(res);
+  };
+  cbWalk.timeout = 1;  // this should time out quickly
+  cbWalk.timeoutVal = 'timeout';
+  creature.walk(cbWalk);
+
+});
+```
+
+
 ## Disabling multiplex
 
 You can always disable multiplexing by passing a `false` as the last parameter on the server and on the client, this is required on both sides. If you disable multiplexing you can omit installing `primus-multiplex`.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ creature.on('ready', function () {
   creature.walk().then((res) => {
     console.log(res);
   }).catch(() => {
-    console.log('did not start walking in time!);
+    console.log('did not start walking in time!');
   });
 
 });

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ creature.on('ready', function () {
 });
 ```
 
-#### Timeouts
+#### Server errors and timeouts
 
-Next to being the current standard for asynchronous operations, Promises are useful in combination with timeout handling: it is possible to define a `timeout` either globally on the resource or local to each resource method (the latter having precedence). In case of timeout (no return value / acknowledgement from server) the promise will reject with the reason `'timeout'`.
-Timeout are optional, by default the Promise will never reject.
-Timeout handling only works with Promises.
+Next to being the current standard for asynchronous operations, Promises are useful for handling server exceptions:
+* the server can reply with the NULL *character* `'\0'` to indicate that an error occurred and no actual result will be provided. This will cause the promise to reject with the reason `'error'`.
+* it is also possible to define a `timeout` (in milliseconds) either globally on the resource or local to each resource method (the latter having precedence). In case of timeout (no return value / acknowledgement from server) the promise will reject with the reason `'timeout'`. Timeouts only work with Promises and are optional.
 
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ creature.on('ready', function () {
 #### Server errors and timeouts
 
 Next to being the current standard for asynchronous operations, Promises are useful for handling server exceptions:
-* the server can reply with the NULL *character* `'\0'` to indicate that an error occurred and no actual result will be provided. This will cause the promise to reject with the reason `'error'`.
+* the server can reply with a string starting with the NULL *character* (e.g. `'\0myerror'`) to indicate that an error occurred and no actual result will be provided. This will cause the promise to reject (here with the reason `'myerror'`).
 * it is also possible to define a `timeout` (in milliseconds) either globally on the resource or local to each resource method (the latter having precedence). In case of timeout (no return value / acknowledgement from server) the promise will reject with the reason `'timeout'`. Timeouts only work with Promises and are optional.
 
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -116,6 +116,18 @@ module.exports = function resource(primus, options) {
       if ('function' === typeof resource[method]) return;
       resource[method] = function () {
         var args = slice.call(arguments);
+        // manage timer if applicable
+        const fn = args.length > 0 && args[args.length-1];
+        const timeout = (fn && fn.timeout) || resource.timeout;
+        if (timeout) {
+          args[args.length-1] = function wrap() {
+            clearTimeout(fn.timer);
+            fn.apply(this, arguments);
+          }
+          fn.timer = setTimeout(() => {
+            fn.apply(this, [fn.timeoutVal || resource.timeoutVal]);
+          }, timeout);
+        }
         // lets send event with the corresponding arguments
         stream.send.apply(stream, [ns + method].concat(args));
       };

--- a/lib/client.js
+++ b/lib/client.js
@@ -116,20 +116,26 @@ module.exports = function resource(primus, options) {
       if ('function' === typeof resource[method]) return;
       resource[method] = function () {
         var args = slice.call(arguments);
-        // manage timer if applicable
         const fn = args.length > 0 && args[args.length-1];
-        const timeout = (fn && fn.timeout) || resource.timeout;
-        if (timeout) {
-          args[args.length-1] = function wrap() {
-            clearTimeout(fn.timer);
-            fn.apply(this, arguments);
-          }
-          fn.timer = setTimeout(() => {
-            fn.apply(this, [fn.timeoutVal || resource.timeoutVal]);
-          }, timeout);
+        if (typeof fn === 'function') {
+          // lets send event with the corresponding arguments
+          stream.send.apply(stream, [ns + method].concat(args));
+        } else {
+          return new Promise((resolve, reject) => {
+            var timer = undefined;
+            var fReply = function fReply(res) {
+              if (timer) clearTimeout(timer);
+              resolve(res);
+            }
+            const timeout = resource[method].timeout || resource.timeout;
+            if (timeout) {
+              timer = setTimeout(() => {
+                reject('timeout');
+              }, timeout);
+            }
+            stream.send.apply(stream, [ns + method].concat(args, fReply));
+          });
         }
-        // lets send event with the corresponding arguments
-        stream.send.apply(stream, [ns + method].concat(args));
       };
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -121,7 +121,7 @@ module.exports = function resource(primus, options) {
           // lets send event with the corresponding arguments
           stream.send.apply(stream, [ns + method].concat(args));
         } else {
-          return new Promise((resolve, reject) => {
+          return new Promise(function(resolve, reject) {
             var timer = undefined;
             var fReply = function fReply(res) {
               if (timer) clearTimeout(timer);
@@ -129,7 +129,7 @@ module.exports = function resource(primus, options) {
             }
             const timeout = resource[method].timeout || resource.timeout;
             if (timeout) {
-              timer = setTimeout(() => {
+              timer = setTimeout(function() {
                 reject('timeout');
               }, timeout);
             }

--- a/lib/client.js
+++ b/lib/client.js
@@ -125,7 +125,7 @@ module.exports = function resource(primus, options) {
             var timer = undefined;
             var fReply = function fReply(res) {
               if (timer) clearTimeout(timer);
-              resolve(res);
+              if (res === '\0') reject('error'); else resolve(res);
             }
             const timeout = resource[method].timeout || resource.timeout;
             if (timeout) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -116,7 +116,7 @@ module.exports = function resource(primus, options) {
       if ('function' === typeof resource[method]) return;
       resource[method] = function () {
         var args = slice.call(arguments);
-        const fn = args.length > 0 && args[args.length-1];
+        var fn = args.length > 0 && args[args.length-1];
         if (typeof fn === 'function') {
           // lets send event with the corresponding arguments
           stream.send.apply(stream, [ns + method].concat(args));
@@ -127,7 +127,7 @@ module.exports = function resource(primus, options) {
               if (timer) clearTimeout(timer);
               if (res === '\0') reject('error'); else resolve(res);
             }
-            const timeout = resource[method].timeout || resource.timeout;
+            var timeout = resource[method].timeout || resource.timeout;
             if (timeout) {
               timer = setTimeout(function() {
                 reject('timeout');

--- a/lib/client.js
+++ b/lib/client.js
@@ -125,7 +125,7 @@ module.exports = function resource(primus, options) {
             var timer = undefined;
             var fReply = function fReply(res) {
               if (timer) clearTimeout(timer);
-              if (res === '\0') reject('error'); else resolve(res);
+              if (typeof res === 'string' && res[0] === '\0') reject(res.substr(1)); else resolve(res);
             }
             var timeout = resource[method].timeout || resource.timeout;
             if (timeout) {

--- a/test/test.js
+++ b/test/test.js
@@ -255,16 +255,15 @@ describe('primus-resource', function (){
 
     creature.on('ready', function () {
       creature.timeout = 5000;  // over test framework timeout, would fail test
-      creature.timeoutVal = 'timeout2';
-      creature.fetch(true, (data) => {
+      creature.fetch(true).then((data) => {
         expect(data).to.be('reply');
-        const cb = (data) => {
-          expect(data).to.be('timeout');
+        creature.fetch.timeout = 500;
+        creature.fetch(false).then((data) => {
+          expect().fail('did not time out as expected');
+        }).catch((reason) => {
+          expect(reason).to.be('timeout');
           done();
-        };
-        cb.timeout = 500;
-        cb.timeoutVal = 'timeout';
-        creature.fetch(false, cb);
+        });
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -252,12 +252,12 @@ describe('primus-resource', function (){
     var creature = cl.resource('creature');
     creature.on('ready', function () {
       creature.timeout = 5000;  // over test framework timeout, would fail test
-      creature.fetch(true).then((data) => {
+      creature.fetch(true).then(function(data) {
         expect(data).to.be('reply');
         creature.fetch.timeout = 500;
-        creature.fetch(false).then((data) => {
+        creature.fetch(false).then(function(data) {
           expect().fail('did not time out as expected');
-        }).catch((reason) => {
+        }).catch(function(reason) {
           if (typeof reason === 'string') {
             expect(reason).to.be('timeout');
             done();
@@ -284,9 +284,9 @@ describe('primus-resource', function (){
     var cl = client(srv, primus);
     var creature = cl.resource('creature');
     creature.on('ready', function () {
-      creature.fetch().then((res) => {
+      creature.fetch().then(function(res) {
         expect().fail('did not reject as expected');
-      }).catch((reason) => {
+      }).catch(function(reason) {
         if (typeof reason === 'string') {
           expect(reason).to.be('error');
           done();

--- a/test/test.js
+++ b/test/test.js
@@ -275,7 +275,7 @@ describe('primus-resource', function (){
 
     function Creature(){}
     Creature.prototype.onfetch = function (spark, fn) {
-      fn('\0');
+      fn('\0error');
     };
     srv.listen(function(){
       primus.resource('creature', new Creature());


### PR DESCRIPTION
I am very fond of `primus-resource`, which I find lean and elegant --I am actually puzzled as to why it is not more popular.

It should probably remain lean, but I propose the following enhancements, which I developed after getting fed up adding timeout handling for each resource method call:
* **support client-side Promises**: a method call will automatically return a promise object if no callback is provided as last argument to the method. The Promise will resolve with the value returned by the server, or might reject if a timeout is defined
* **ability to define an optional timeout** at resource or method level, which will cause Promises to reject if the server does not respond in time (note: timeouts only work in conjunction with Promises)

This change is fairly light and backward-compatible: old code will just ignore the resource method return value.

A test case was added and the README updated with the new functionality.